### PR TITLE
policy: disable EdgeGestureService

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -2176,7 +2176,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             }
 
             final boolean useEdgeService = CMSettings.System.getIntForUser(resolver,
-                    CMSettings.System.USE_EDGE_SERVICE_FOR_GESTURES, 1, UserHandle.USER_CURRENT) == 1;
+                    CMSettings.System.USE_EDGE_SERVICE_FOR_GESTURES, 0, UserHandle.USER_CURRENT) == 1;
             if (useEdgeService ^ mUsingEdgeGestureServiceForGestures && mSystemReady) {
                 if (!mUsingEdgeGestureServiceForGestures && useEdgeService) {
                     mUsingEdgeGestureServiceForGestures = true;


### PR DESCRIPTION
Nothing uses this anymore, and it causes issues on
high dpi devices.

EdgeGestureTracker doesn't allow for much touch slop in detecting
edge gestures.  Many supported CM devices incur a certain amount of
slop when starting from an edge.  For example, this case is often
observed:

(x,y), from portrait orientation:

pt1: (100,10)
pt2: (102,0)
pt3: (102,12)
pt4: (102,16)
...

EdgeGestureTracker determines this can't be a valid swipe down because
of the touch slop from pt1 -> pt2.  It observes that you've started
swiping up and cancels detection at that point.

SystemGesturesPointerEventListener doesn't immediately stop detecting
an edge gesture when pt2 is observed.  It continues to try to detect
the gesture and effectively ignores the slop.

SAMBAR-1233
Change-Id: I3734d8628392bfa010835ef6c271456a1bc509cd
