### PR TITLE
StrictMode: fix deserialization of ViolationInfo on large stacks

### DIFF
--- a/core/java/android/os/StrictMode.java
+++ b/core/java/android/os/StrictMode.java
@@ -1928,9 +1928,9 @@ public final class StrictMode {
                 // so we'll report it and bail on all of the current strict mode violations
                 // we currently are maintaining for this thread.
                 // First, drain the remaining violations from the parcel.
-                while (i < numViolations) {
+                i++;  // Skip the current entry.
+                for (; i < numViolations; i++) {
                     info = new ViolationInfo(p, !currentlyGathering);
-                    i++;
                 }
                 // Next clear out all gathered violations.
                 clearGatheredViolations();


### PR DESCRIPTION
When a large stack trace is encountered, one too many ViolationInfo
objects would be drained, which may cause a system_server crash
when readStringArray() is called on incorrect data.

Change-Id: Icb30d0402638ea5b6d63004b598d2f0bb276d685
(cherry picked from commit 1e60f9b9ae10d46d028c19c90cf0f52d40ca620a)
