### PR TITLE
SystemUI: fix always_show_roaming

### DIFF
--- a/packages/SystemUI/res/layout/mobile_signal_group.xml
+++ b/packages/SystemUI/res/layout/mobile_signal_group.xml
@@ -17,13 +17,13 @@
 ** limitations under the License.
 */
 -->
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:systemui="http://schemas.android.com/apk/res-auto"
     android:id="@+id/mobile_combo"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    >
+    android:orientation="horizontal">
     <FrameLayout
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
@@ -57,4 +57,4 @@
             android:visibility="gone"
             android:src="@drawable/stat_sys_data_roaming"
             />
-</FrameLayout>
+</LinearLayout>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/SignalClusterView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/SignalClusterView.java
@@ -562,6 +562,7 @@ public class SignalClusterView
         public void setIconTint(int tint, float darkIntensity) {
             applyDarkIntensity(darkIntensity, mMobile, mMobileDark);
             setTint(mMobileType, tint);
+            setTint(mMobileRoaming, tint);
         }
     }
 }


### PR DESCRIPTION
The roaming indicator overlaps with the signal view
fix it to match the cm-12.1 layout and tint it as well

RM-208
Change-Id: I3b070b867fbf070cdf20cf01eb67c8e4688ac881
